### PR TITLE
Improve dashboard by month and by category

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -14,7 +14,8 @@ const formatDateToMMYY = (date) => {
   return `${month}-${year}`;
 };
 
-exports.getTotals = onRequest({ cors: true }, async (req, res) => {
+// Returns I/O total for all categories and the passed year
+exports.getAllTotals = onRequest({ cors: true }, async (req, res) => {
   const { userId, year } = req.body.data;
   if (!userId) {
     res.status(400).send('User ID is required');
@@ -37,35 +38,6 @@ exports.getTotals = onRequest({ cors: true }, async (req, res) => {
         return transactionYear === filterYear;
       })
       : transactions;
-
-    const groupedByMonthAndYear = filteredTransactions.reduce(
-      (acc, transaction) => {
-        const key = formatDateToMMYY(transaction.date.toDate());
-
-        if (!acc[key]) {
-          acc[key] = { incomingTotal: 0, outgoingTotal: 0 };
-        }
-
-        if (transaction.category.id === 'usd') {
-          if (transaction.income) {
-            acc[key].incomingTotal += transaction.amount;
-          } else {
-            acc[key].outgoingTotal += transaction.amount;
-          }
-        }
-
-        return acc;
-      },
-      {},
-    );
-    const totalsByMonthAndYear = Object.keys(groupedByMonthAndYear).map(
-      (key) => ({
-        monthYear: key,
-        incomingTotal: groupedByMonthAndYear[key].incomingTotal,
-        outgoingTotal: groupedByMonthAndYear[key].outgoingTotal
-      }),
-    );
-
 
     const categoryTotals = {};
     filteredTransactions.forEach((transaction) => {
@@ -100,9 +72,67 @@ exports.getTotals = onRequest({ cors: true }, async (req, res) => {
       }
     });
 
-    res.status(200).json({ data: { totalsByMonthAndYear, categoryTotals } });
+    res.status(200).json({ data: categoryTotals });
   } catch (error) {
     console.error('Error retrieving transactions:', error);
-    res.status(500).send('Internal Server Error');
+    res.status(500).send({ name: 'Internal Server Error', error });
+  }
+});
+
+// Returns total by category for each month
+exports.getMonthlyTotalsByCategory = onRequest({ cors: true }, async (req, res) => {
+  const { userId, year, category } = req.body.data;
+  if (!userId) {
+    res.status(400).send('User ID is required');
+    return;
+  }
+  const filterYear = year ? parseInt(year, 10) : null;
+
+  try {
+    const snapshot = await getFirestore()
+      .collection('transactions')
+      .where('userId', '==', userId)
+      .where('category.id', '==', category)
+      .where('saving', '==', false)
+      .orderBy('date', 'asc')
+      .get();
+
+    const transactions = snapshot.docs.map((doc) => doc.data());
+    const filteredTransactions = filterYear
+      ? transactions.filter((transaction) => {
+        const transactionYear = transaction.date.toDate().getFullYear();
+        return transactionYear === filterYear;
+      })
+      : transactions;
+
+    const groupedByMonthAndYear = filteredTransactions.reduce(
+      (acc, transaction) => {
+        const key = formatDateToMMYY(transaction.date.toDate());
+
+        if (!acc[key]) {
+          acc[key] = { incomingTotal: 0, outgoingTotal: 0 };
+        }
+
+        if (transaction.income) {
+          acc[key].incomingTotal += transaction.amount;
+        } else {
+          acc[key].outgoingTotal += transaction.amount;
+        }
+
+        return acc;
+      },
+      {},
+    );
+    const totalByMonthAndYear = Object.keys(groupedByMonthAndYear).map(
+      (key) => ({
+        monthYear: key,
+        incomingTotal: groupedByMonthAndYear[key].incomingTotal,
+        outgoingTotal: groupedByMonthAndYear[key].outgoingTotal
+      }),
+    );
+    res.status(200).json({ data: totalByMonthAndYear });
+  } catch (error) {
+    console.error('Error retrieving transactions:', error);
+    res.status(500).send({ name: 'Internal Server Error', error });
   }
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 
 import dayjs from 'dayjs';
 import 'dayjs/locale/es';
+import CategoryProvider from 'context/CategoryContext';
 dayjs.locale('es');
 
 const App = () => {
@@ -27,7 +28,9 @@ const App = () => {
       <CssBaseline />
       <LocalizationProvider dateAdapter={AdapterDayjs}>
         <UserProvider>
-          <Routes />
+          <CategoryProvider>
+            <Routes />
+          </CategoryProvider>
         </UserProvider>
       </LocalizationProvider>
     </ThemeProvider>

--- a/src/components/category/CategoryTotalCard.tsx
+++ b/src/components/category/CategoryTotalCard.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardActionArea,
   CardContent,
+  styled,
   SxProps,
   Typography,
 } from '@mui/material';
@@ -13,6 +14,14 @@ import { toLocaleAmount } from 'utils/toLocaleAmount';
 import { useContext } from 'react';
 import { getTotalAmount } from 'utils/getTotalAmount';
 import { CategoryContext } from 'context/CategoryContext';
+
+export const CategoryContainerBox = styled(Box)(() => ({
+  display: 'flex',
+  gap: '8px',
+  padding: '4px',
+  overflow: 'auto',
+  whiteSpace: 'nowrap',
+}));
 
 export const TotalCard = ({
   title,
@@ -146,15 +155,7 @@ export const CategoriesTotalList = ({
 
   return (
     <Box>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          padding: 0.5,
-          overflow: 'auto',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      <CategoryContainerBox>
         {categories?.map((category) => (
           <CategoryTotalCard
             key={category.id}
@@ -166,16 +167,8 @@ export const CategoriesTotalList = ({
             isSelected={selectedCategory?.id === category.id}
           />
         ))}
-      </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          gap: 1,
-          padding: 0.5,
-          overflow: 'auto',
-          whiteSpace: 'nowrap',
-        }}
-      >
+      </CategoryContainerBox>
+      <CategoryContainerBox>
         {selectedCategory?.subcategories?.map((subcategory) => (
           <SubCategoryTotalCard
             key={subcategory.id}
@@ -190,7 +183,7 @@ export const CategoriesTotalList = ({
             isSelected={selectedSubCategory?.id === subcategory.id}
           />
         ))}
-      </Box>
+      </CategoryContainerBox>
     </Box>
   );
 };

--- a/src/components/category/CategoryTotalCard.tsx
+++ b/src/components/category/CategoryTotalCard.tsx
@@ -10,9 +10,9 @@ import {
 import { Amount } from 'components/common/Amount';
 import { Category, SubCategory, Transaction } from 'types/Transaction';
 import { toLocaleAmount } from 'utils/toLocaleAmount';
-import { useEffect, useState } from 'react';
-import { getAllCategories } from 'services/categories';
+import { useContext } from 'react';
 import { getTotalAmount } from 'utils/getTotalAmount';
+import { CategoryContext } from 'context/CategoryContext';
 
 export const TotalCard = ({
   title,
@@ -133,42 +133,16 @@ export const TotalCards = ({
 
 export const CategoriesTotalList = ({
   transactions,
-  selectedCategory,
-  setSelectedCategory,
-  selectedSubCategory,
-  setSelectedSubCategory,
 }: {
   transactions: Transaction[];
-  selectedCategory: Category | undefined;
-  setSelectedCategory: (category: Category | undefined) => void;
-  selectedSubCategory: SubCategory | undefined;
-  setSelectedSubCategory: (category: SubCategory | undefined) => void;
 }) => {
-  const [categories, setCategories] = useState<Category[]>();
-  useEffect(() => {
-    const getCategories = async () => {
-      const response = await getAllCategories();
-      setCategories(
-        (response as Category[]).sort((a, b) => b.id.localeCompare(a.id))
-      );
-    };
-    getCategories();
-  }, []);
-
-  const onCategoryClick = (category: Category) => {
-    if (selectedCategory?.id === category.id) {
-      setSelectedCategory(undefined);
-    } else {
-      setSelectedCategory(category);
-    }
-  };
-  const onSubCategoryClick = (subCategory: SubCategory) => {
-    if (subCategory?.id === selectedSubCategory?.id) {
-      setSelectedSubCategory(undefined);
-    } else {
-      setSelectedSubCategory(subCategory);
-    }
-  };
+  const {
+    categories,
+    onCategoryClick,
+    onSubCategoryClick,
+    selectedCategory,
+    selectedSubCategory,
+  } = useContext(CategoryContext);
 
   return (
     <Box>

--- a/src/components/dashboard/CategoryTotals.tsx
+++ b/src/components/dashboard/CategoryTotals.tsx
@@ -1,0 +1,91 @@
+import { Grid, Typography } from '@mui/material';
+import {
+  CategoryContainerBox,
+  CategoryTotalCard,
+  SubCategoryTotalCard,
+} from 'components/category/CategoryTotalCard';
+import { CategoryContext } from 'context/CategoryContext';
+import { UserContext } from 'context/UserContext';
+import { FirestoreError } from 'firebase/firestore';
+import { Loading } from 'pages/Loading';
+import { useContext, useState, useEffect } from 'react';
+import { getAllTotals } from 'services/dashboard';
+import { CategoryTotal } from 'types/Dashboard';
+
+export const CategoryTotals = ({ year }: { year: number }) => {
+  const { user } = useContext(UserContext);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [categoryData, setCategoryData] = useState<CategoryTotal[]>([]);
+  const { categories, selectedCategory, onCategoryClick } =
+    useContext(CategoryContext);
+
+  useEffect(() => {
+    const fetchAllTotals = async () => {
+      setLoading(true);
+      if (user?.uid) {
+        try {
+          const categoryTotals = await getAllTotals({
+            userId: user.uid,
+            year,
+          });
+          setCategoryData(categoryTotals);
+          setLoading(false);
+        } catch (err) {
+          console.error(err);
+          const error = err as FirestoreError;
+          setError(`${error.name} (${error.code}): ${error.message}`);
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchAllTotals();
+  }, [user?.uid, year]);
+
+  if (loading) {
+    return <Loading />;
+  }
+  if (error) {
+    return <Typography sx={{ wordWrap: 'break-word' }}>{error}</Typography>;
+  }
+
+  return (
+    <Grid item xs={3} sx={{ marginBottom: 4 }}>
+      <CategoryContainerBox>
+        {categories?.map((category) => {
+          const categoryTotal = categoryData?.find(
+            (x) => x.category.id === category.id
+          );
+          return categoryTotal?.total ? (
+            <CategoryTotalCard
+              key={category.id}
+              amount={categoryTotal?.total || 0}
+              category={category}
+              onCategoryClick={() => onCategoryClick(category)}
+              isSelected={selectedCategory?.id === category.id}
+            />
+          ) : null;
+        })}
+      </CategoryContainerBox>
+      <CategoryContainerBox>
+        {selectedCategory?.subcategories?.map((subCategory) => {
+          const categoryTotal = categoryData?.find(
+            (x) => x.category.id === selectedCategory.id
+          );
+          const subCategoryTotal = categoryTotal?.subcategories.find(
+            (x) => x.subcategory.id === subCategory.id
+          );
+          return (
+            <SubCategoryTotalCard
+              key={subCategory.id}
+              amount={subCategoryTotal?.total || 0}
+              category={selectedCategory}
+              subCategory={subCategory}
+            />
+          );
+        })}
+      </CategoryContainerBox>
+    </Grid>
+  );
+};

--- a/src/components/dashboard/MonthlyTotals.tsx
+++ b/src/components/dashboard/MonthlyTotals.tsx
@@ -1,0 +1,110 @@
+import { Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { TotalCards } from 'components/category/CategoryTotalCard';
+import { MonthlyTotalsBarChart } from './MonthlyTotalsBarChart';
+import { useContext, useEffect, useState } from 'react';
+import { MonthlyTotal } from 'types/Dashboard';
+import { CategoryContext } from 'context/CategoryContext';
+import { UserContext } from 'context/UserContext';
+import { getMonthlyTotalsByCategory } from 'services/dashboard';
+import { FirestoreError } from 'firebase/firestore';
+import { Loading } from 'pages/Loading';
+
+const getTotalsFromMonthlyData = (monthlyData: MonthlyTotal[]) => {
+  const totals = monthlyData.reduce(
+    (acc, current) => {
+      acc.incoming += current.incomingTotal;
+      acc.outgoing += current.outgoingTotal;
+      return acc;
+    },
+    { incoming: 0, outgoing: 0 }
+  );
+
+  return totals;
+};
+
+export const MonthlyTotals = ({ year }: { year: number }) => {
+  const { breakpoints } = useTheme();
+  const isMobileScreen = useMediaQuery(breakpoints.only('xs'));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [monthlyData, setMonthlyData] = useState<MonthlyTotal[]>([]);
+  const [incomingTotal, setIncomingTotal] = useState(0);
+  const [outgoingTotal, setOutgoingTotal] = useState(0);
+
+  const { user } = useContext(UserContext);
+  const { selectedCategory } = useContext(CategoryContext);
+
+  useEffect(() => {
+    const fetchMonthlyTotals = async () => {
+      if (user?.uid && selectedCategory) {
+        setLoading(true);
+        try {
+          const monthlyData = await getMonthlyTotalsByCategory({
+            userId: user.uid,
+            year,
+            category: selectedCategory.id,
+          });
+          setMonthlyData(monthlyData);
+          setLoading(false);
+        } catch (err) {
+          console.error(err);
+          const error = err as FirestoreError;
+          setError(`${error.name} (${error.code}): ${error.message}`);
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMonthlyTotals();
+  }, [selectedCategory, user?.uid, year]);
+
+  useEffect(() => {
+    if (monthlyData.length) {
+      const totals = getTotalsFromMonthlyData(monthlyData);
+      setIncomingTotal(totals.incoming);
+      setOutgoingTotal(totals.outgoing);
+    }
+  }, [monthlyData]);
+
+  if (loading) {
+    return <Loading />;
+  }
+  if (error) {
+    return <Typography sx={{ wordWrap: 'break-word' }}>{error}</Typography>;
+  }
+
+  return (
+    <Grid item xs={3} container columns={3} sx={{ maxHeight: '60%' }}>
+      {selectedCategory ? (
+        <>
+          {!loading && error && (
+            <Typography sx={{ wordWrap: 'break-word' }}>{error}</Typography>
+          )}
+          {!loading && selectedCategory && monthlyData.length > 0 && (
+            <>
+              <Grid
+                item
+                xs={3}
+                sm={2}
+                sx={{ height: isMobileScreen ? '50%' : '100%' }}
+              >
+                <MonthlyTotalsBarChart monthlyData={monthlyData} />
+              </Grid>
+              <Grid item xs={3} sm={1}>
+                <TotalCards
+                  incomingTotal={incomingTotal}
+                  outgoingTotal={outgoingTotal}
+                  sx={{ flexDirection: 'column' }}
+                />
+              </Grid>
+            </>
+          )}
+        </>
+      ) : (
+        <Typography>
+          Selecciona una categoria para ver los totales por mes
+        </Typography>
+      )}
+    </Grid>
+  );
+};

--- a/src/context/CategoryContext.tsx
+++ b/src/context/CategoryContext.tsx
@@ -1,0 +1,79 @@
+import { createContext, PropsWithChildren, useEffect, useState } from 'react';
+import { Category, SubCategory } from 'types/Transaction';
+import { getAllCategories } from 'services/categories';
+
+export interface CategoryContextProps {
+  categories: Category[] | null;
+  loading: boolean;
+  onCategoryClick: (category: Category) => void;
+  onSubCategoryClick: (subCategory: SubCategory) => void;
+  selectedCategory?: Category;
+  selectedSubCategory?: SubCategory;
+  setSelectedCategory: React.Dispatch<
+    React.SetStateAction<Category | undefined>
+  >;
+  setSelectedSubCategory: React.Dispatch<
+    React.SetStateAction<SubCategory | undefined>
+  >;
+}
+export const CategoryContext = createContext<CategoryContextProps>({
+  categories: [],
+  loading: false,
+  onCategoryClick: () => true,
+  onSubCategoryClick: () => true,
+  setSelectedCategory: () => true,
+  setSelectedSubCategory: () => true,
+});
+
+const CategoryProvider = ({ children }: PropsWithChildren) => {
+  const [loading, setLoading] = useState(true);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState<Category>();
+  const [selectedSubCategory, setSelectedSubCategory] = useState<SubCategory>();
+
+  useEffect(() => {
+    const getCategories = async () => {
+      setLoading(true);
+      const response = await getAllCategories();
+      setCategories(
+        (response as Category[]).sort((a, b) => b.id.localeCompare(a.id))
+      );
+      setLoading(false);
+    };
+    getCategories();
+  }, []);
+
+  const onCategoryClick = (category: Category) => {
+    if (selectedCategory?.id === category.id) {
+      setSelectedCategory(undefined);
+    } else {
+      setSelectedCategory(category);
+    }
+  };
+  const onSubCategoryClick = (subCategory: SubCategory) => {
+    if (subCategory?.id === selectedSubCategory?.id) {
+      setSelectedSubCategory(undefined);
+    } else {
+      setSelectedSubCategory(subCategory);
+    }
+  };
+
+  const contextValue: CategoryContextProps = {
+    categories,
+    loading,
+    onCategoryClick,
+    onSubCategoryClick,
+    selectedCategory,
+    setSelectedCategory,
+    selectedSubCategory,
+    setSelectedSubCategory,
+  };
+
+  return (
+    <CategoryContext.Provider value={contextValue}>
+      {children}
+    </CategoryContext.Provider>
+  );
+};
+
+export default CategoryProvider;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,96 +1,20 @@
-import { Box, Grid, Typography, useMediaQuery, useTheme } from '@mui/material';
-import {
-  CategoryTotalCard,
-  SubCategoryTotalCard,
-  TotalCards,
-} from 'components/category/CategoryTotalCard';
-import { MonthlyTotalsBarChart } from 'components/dashboard/MonthlyTotalsBarChart';
-import { UserContext } from 'context/UserContext';
-import { useContext, useEffect, useState } from 'react';
-import { getYearlyTotals } from 'services/dashboard';
-import { CategoryTotal, MonthlyTotal } from 'types/Dashboard';
-import { Loading } from './Loading';
-import { FirestoreError } from 'firebase/firestore';
+import { Box, Grid, Typography } from '@mui/material';
+import { useState } from 'react';
 import { MonthSelector } from 'components/common/MonthSelector';
-
-const getTotalsFromMonthlyData = (monthlyData: MonthlyTotal[]) => {
-  const totals = monthlyData.reduce(
-    (acc, current) => {
-      acc.incoming += current.incomingTotal;
-      acc.outgoing += current.outgoingTotal;
-      return acc;
-    },
-    { incoming: 0, outgoing: 0 }
-  );
-
-  return totals;
-};
+import { MonthlyTotals } from 'components/dashboard/MonthlyTotals';
+import { CategoryTotals } from 'components/dashboard/CategoryTotals';
 
 export const Dashboard = () => {
-  const { breakpoints } = useTheme();
-  const isMobileScreen = useMediaQuery(breakpoints.only('xs'));
-  const { user } = useContext(UserContext);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [monthlyData, setMonthlyData] = useState<MonthlyTotal[]>([]);
-  const [categoryData, setCategoryData] = useState<CategoryTotal[]>([]);
-  const [incomingTotal, setIncomingTotal] = useState(0);
-  const [outgoingTotal, setOutgoingTotal] = useState(0);
   const [year, setYear] = useState(0);
-  const [selectedCategory, setSelectedCategory] = useState<CategoryTotal>();
-
-  useEffect(() => {
-    const fetchYearlyTotals = async () => {
-      setLoading(true);
-      if (user?.uid) {
-        try {
-          const { totalsByMonthAndYear, categoryTotals } =
-            await getYearlyTotals(user.uid, year);
-          setMonthlyData(totalsByMonthAndYear);
-          setCategoryData(categoryTotals);
-          setLoading(false);
-        } catch (error) {
-          console.error(error);
-          setError((error as FirestoreError).message);
-          setLoading(false);
-        }
-      }
-    };
-
-    fetchYearlyTotals();
-  }, [user?.uid, year]);
-
-  useEffect(() => {
-    if (monthlyData.length) {
-      const totals = getTotalsFromMonthlyData(monthlyData);
-      setIncomingTotal(totals.incoming);
-      setOutgoingTotal(totals.outgoing);
-    }
-  }, [monthlyData]);
-
-  const onCategoryClick = (category: CategoryTotal) => {
-    if (selectedCategory?.category.id === category.category.id) {
-      setSelectedCategory(undefined);
-    } else {
-      setSelectedCategory(category);
-    }
-  };
-
-  if (loading) {
-    return <Loading />;
-  }
-  if (error) {
-    return <Typography sx={{ wordWrap: 'break-word' }}>{error}</Typography>;
-  }
 
   return (
-    <Box sx={{ height: '100%' }}>
+    <Box sx={{ height: '100%', paddingTop: '16px' }}>
       <Box
         sx={{
           display: 'flex',
           alignItems: 'center',
           flexWrap: 'wrap',
-          margin: '16px 0 8px',
+          marginBotto: '8px',
           justifyContent: 'space-between',
         }}
       >
@@ -99,102 +23,10 @@ export const Dashboard = () => {
         </Typography>
         <MonthSelector year={year} setYear={setYear} />
       </Box>
-      {!loading && !error && !monthlyData?.length ? (
-        <Typography>No se encontraron totales para este año</Typography>
-      ) : (
-        <>
-          <Grid
-            container
-            columns={3}
-            columnSpacing={2}
-            sx={{ height: '60%', paddingY: 2 }}
-          >
-            <Grid item xs={3} sm={2}>
-              <MonthlyTotalsBarChart monthlyData={monthlyData} />
-            </Grid>
-            <Grid item xs={3} sm={1}>
-              <TotalCards
-                incomingTotal={incomingTotal}
-                outgoingTotal={outgoingTotal}
-                sx={{ flexDirection: 'column' }}
-              />
-            </Grid>
-          </Grid>
-          <Box>
-            <Typography sx={{ fontWeight: 600, margin: '16px 0 8px' }}>
-              Total acumulado por categoría
-            </Typography>
-            <Box
-              sx={(theme) => ({
-                display: 'grid',
-                [theme.breakpoints.up('sm')]: {
-                  display: 'flex',
-                },
-                gap: 1,
-                padding: 0.5,
-                overflow: 'auto',
-                whiteSpace: 'nowrap',
-              })}
-            >
-              {categoryData.map((categoryTotal) => (
-                <Box key={categoryTotal.category.id}>
-                  <CategoryTotalCard
-                    amount={categoryTotal.total}
-                    category={categoryTotal.category}
-                    onCategoryClick={() => onCategoryClick(categoryTotal)}
-                  />
-                  {isMobileScreen &&
-                    selectedCategory?.category.id ===
-                      categoryTotal.category.id && (
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          gap: 1,
-                          paddingY: 0.5,
-                          paddingX: 1,
-                          overflow: 'auto',
-                          whiteSpace: 'nowrap',
-                        }}
-                      >
-                        {selectedCategory?.subcategories?.map(
-                          (subcategoryTotal) => (
-                            <SubCategoryTotalCard
-                              key={subcategoryTotal.subcategory.id}
-                              amount={subcategoryTotal.total}
-                              category={selectedCategory.category}
-                              subCategory={subcategoryTotal.subcategory}
-                            />
-                          )
-                        )}
-                      </Box>
-                    )}
-                </Box>
-              ))}
-            </Box>
-            {!isMobileScreen && (
-              <Box
-                sx={{
-                  display: 'flex',
-                  gap: 1,
-                  paddingY: 0.5,
-                  paddingX: 1,
-                  overflow: 'auto',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {selectedCategory?.subcategories?.map((subcategoryTotal) => (
-                  <SubCategoryTotalCard
-                    key={subcategoryTotal.subcategory.id}
-                    amount={subcategoryTotal.total}
-                    category={selectedCategory.category}
-                    subCategory={subcategoryTotal.subcategory}
-                  />
-                ))}
-              </Box>
-            )}
-          </Box>
-        </>
-      )}
+      <Grid container columns={3} columnSpacing={2} sx={{ paddingY: 2 }}>
+        <CategoryTotals year={year} />
+        <MonthlyTotals year={year} />
+      </Grid>
     </Box>
   );
 };

--- a/src/pages/Savings.tsx
+++ b/src/pages/Savings.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import { Category, SubCategory, Transaction } from 'types/Transaction';
+import { Transaction } from 'types/Transaction';
 import { useContext, useEffect, useState } from 'react';
 import { where } from 'firebase/firestore';
 import { getTransactionsSnapshot } from 'services/transactions';
@@ -17,6 +17,7 @@ import { UserContext } from 'context/UserContext';
 import { TransactionList } from 'components/transaction/TransactionList';
 import { TransactionFormModal } from 'components/transaction/TransactionFormModal';
 import { CategoriesTotalList } from 'components/category/CategoryTotalCard';
+import { CategoryContext } from 'context/CategoryContext';
 
 export const Savings = () => {
   const { user } = useContext(UserContext);
@@ -26,9 +27,12 @@ export const Savings = () => {
   const [loading, setLoading] = useState(false);
   const [newTransactionModalOpen, setNewTransactionModalOpen] = useState(false);
   const [showTotals, setShowTotals] = useState(true);
-  const [filteringCategory, setFilteringCategory] = useState<Category>();
-  const [filteringSubCategory, setFilteringSubCategory] =
-    useState<SubCategory>();
+  const {
+    selectedCategory,
+    selectedSubCategory,
+    setSelectedCategory,
+    setSelectedSubCategory,
+  } = useContext(CategoryContext);
 
   useEffect(() => {
     setLoading(true);
@@ -52,27 +56,32 @@ export const Savings = () => {
 
   useEffect(() => {
     setFilteringSavings(
-      filteringCategory
-        ? savings.filter((x) => x.category.id === filteringCategory?.id)
+      selectedCategory
+        ? savings.filter((x) => x.category.id === selectedCategory?.id)
         : savings
     );
-  }, [filteringCategory, savings]);
+  }, [selectedCategory, savings]);
 
   useEffect(() => {
-    if (filteringSubCategory) {
+    if (selectedSubCategory) {
       const filtered = savings.filter(
-        (x) => x.category.subcategory?.id === filteringSubCategory?.id
+        (x) => x.category.subcategory?.id === selectedSubCategory?.id
       );
       setFilteringSavings(filtered);
-    } else if (filteringCategory) {
+    } else if (selectedCategory) {
       setFilteringSavings(
-        savings.filter((x) => x.category.id === filteringCategory?.id)
+        savings.filter((x) => x.category.id === selectedCategory?.id)
       );
     } else {
       setFilteringSavings(savings);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filteringSubCategory, savings]);
+  }, [selectedSubCategory, savings]);
+
+  useEffect(() => {
+    setSelectedCategory(undefined);
+    setSelectedSubCategory(undefined);
+  }, [setSelectedCategory, setSelectedSubCategory]);
 
   return (
     <>
@@ -110,13 +119,7 @@ export const Savings = () => {
                 {showTotals ? 'Ocultar' : 'Ver'} totales
               </AccordionSummary>
               <AccordionDetails sx={{ padding: 0 }}>
-                <CategoriesTotalList
-                  transactions={savings}
-                  setSelectedCategory={setFilteringCategory}
-                  selectedCategory={filteringCategory}
-                  setSelectedSubCategory={setFilteringSubCategory}
-                  selectedSubCategory={filteringSubCategory}
-                />
+                <CategoriesTotalList transactions={savings} />
               </AccordionDetails>
             </Accordion>
             <TransactionList transactions={filteringSavings} saving />

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -11,7 +11,7 @@ import {
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SyncAltIcon from '@mui/icons-material/SyncAlt';
-import { Category, SubCategory, Transaction } from 'types/Transaction';
+import { Transaction } from 'types/Transaction';
 import { useContext, useEffect, useState } from 'react';
 import { Timestamp, where } from 'firebase/firestore';
 import { getTransactionsSnapshot } from 'services/transactions';
@@ -27,6 +27,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { BuySellModal } from 'components/transaction/BuySellModal';
 import { getTotalAmount } from 'utils/getTotalAmount';
 import { Loading } from './Loading';
+import { CategoryContext } from 'context/CategoryContext';
 
 export const Transactions = () => {
   const { user } = useContext(UserContext);
@@ -41,9 +42,12 @@ export const Transactions = () => {
   const [buySellModalOpen, setBuySellModalOpen] = useState(false);
   const [showTotals, setShowTotals] = useState(true);
   const [month, setMonth] = useState<Dayjs>(dayjs());
-  const [filteringCategory, setFilteringCategory] = useState<Category>();
-  const [filteringSubCategory, setFilteringSubCategory] =
-    useState<SubCategory>();
+  const {
+    selectedCategory,
+    selectedSubCategory,
+    setSelectedCategory,
+    setSelectedSubCategory,
+  } = useContext(CategoryContext);
 
   useEffect(() => {
     setLoading(true);
@@ -75,33 +79,33 @@ export const Transactions = () => {
 
   useEffect(() => {
     setFilteredTransactions(
-      filteringCategory
-        ? transactions.filter((x) => x.category.id === filteringCategory?.id)
+      selectedCategory
+        ? transactions.filter((x) => x.category.id === selectedCategory?.id)
         : transactions
     );
-  }, [filteringCategory, transactions]);
+  }, [selectedCategory, transactions]);
 
   useEffect(() => {
-    if (filteringSubCategory) {
+    if (selectedSubCategory) {
       const filtered = transactions.filter(
-        (x) => x.category.subcategory?.id === filteringSubCategory?.id
+        (x) => x.category.subcategory?.id === selectedSubCategory?.id
       );
       setFilteredTransactions(filtered);
-    } else if (filteringCategory) {
+    } else if (selectedCategory) {
       setFilteredTransactions(
-        transactions.filter((x) => x.category.id === filteringCategory?.id)
+        transactions.filter((x) => x.category.id === selectedCategory?.id)
       );
     } else {
       setFilteredTransactions(transactions);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filteringSubCategory, transactions]);
+  }, [selectedSubCategory, transactions]);
 
   useEffect(() => {
     setFilteredTransactions([]);
-    setFilteringCategory(undefined);
-    setFilteringSubCategory(undefined);
-  }, [month]);
+    setSelectedCategory(undefined);
+    setSelectedSubCategory(undefined);
+  }, [month, setSelectedCategory, setSelectedSubCategory]);
 
   const actions = [
     {
@@ -117,7 +121,7 @@ export const Transactions = () => {
   ];
 
   const getIOTransactions = (income: boolean) => {
-    if (filteringCategory) {
+    if (selectedCategory) {
       return filteredTransactions.filter((x) => x.income === income);
     }
     return transactions.filter(
@@ -166,13 +170,7 @@ export const Transactions = () => {
                   incomingTotal={getTotalAmount(getIOTransactions(true))}
                   outgoingTotal={getTotalAmount(getIOTransactions(false))}
                 />
-                <CategoriesTotalList
-                  transactions={transactions}
-                  setSelectedCategory={setFilteringCategory}
-                  selectedCategory={filteringCategory}
-                  setSelectedSubCategory={setFilteringSubCategory}
-                  selectedSubCategory={filteringSubCategory}
-                />
+                <CategoriesTotalList transactions={transactions} />
               </AccordionDetails>
             </Accordion>
             <TransactionList transactions={filteredTransactions} />

--- a/src/services/dashboard.ts
+++ b/src/services/dashboard.ts
@@ -1,46 +1,74 @@
 import { httpsCallable } from 'firebase/functions';
 import { functions } from 'firestore/config';
 import { Category, SubCategory } from 'types/Transaction';
-
-interface calculateYearlyTotalsResponse {
+interface GetAllTotalsFunctionResponse {
   data: {
-    categoryTotals: {
-      [key: string]: {
-        category: Category;
-        total: number;
-        subcategories: {
-          [subKey: string]: {
-            total: number;
-            subcategory: SubCategory;
-          };
+    [key: string]: {
+      category: Category;
+      total: number;
+      subcategories: {
+        [subKey: string]: {
+          total: number;
+          subcategory: SubCategory;
         };
       };
     };
-    totalsByMonthAndYear: {
-      monthYear: string;
-      incomingTotal: number;
-      outgoingTotal: number;
-    }[];
   };
 }
 
-const getTotals = httpsCallable(functions, 'getTotals');
+interface TotalByMonthAndYear {
+  monthYear: string;
+  incomingTotal: number;
+  outgoingTotal: number;
+}
+interface GetMonthlyTotalsByCategoryFunctionResponse {
+  data: TotalByMonthAndYear[];
+}
 
-export const getYearlyTotals = async (userId: string, year: number) => {
+const getAllTotalsFunction = httpsCallable(functions, 'getAllTotals');
+const getMonthlyTotalsByCategoryFunction = httpsCallable(
+  functions,
+  'getMonthlyTotalsByCategory'
+);
+
+export const getAllTotals = async ({
+  userId,
+  year,
+}: {
+  userId: string;
+  year: number;
+}) => {
   try {
-    const result = (await getTotals({
+    const result = (await getAllTotalsFunction({
       userId,
       year,
-    })) as calculateYearlyTotalsResponse;
-    const { totalsByMonthAndYear, categoryTotals } = result.data;
+    })) as GetAllTotalsFunctionResponse;
+    const categoryTotals = result.data;
     const parsedCategoryTotals = Object.values(categoryTotals).map((x) => ({
       ...x,
       subcategories: Object.values(x.subcategories),
     }));
-    return {
-      totalsByMonthAndYear,
-      categoryTotals: parsedCategoryTotals,
-    };
+    return parsedCategoryTotals;
+  } catch (error) {
+    throw error;
+  }
+};
+export const getMonthlyTotalsByCategory = async ({
+  userId,
+  year,
+  category,
+}: {
+  userId: string;
+  year: number;
+  category: string;
+}) => {
+  try {
+    const result = (await getMonthlyTotalsByCategoryFunction({
+      userId,
+      year,
+      category,
+    })) as GetMonthlyTotalsByCategoryFunctionResponse;
+    return result.data;
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
- Split `getTotals` query into two different queries to reduce scope of each one: `getAllTotals` and `getMonthlyTotalsByCategory`
- Create category context to take care of fetching categories and avoid duplicated code for selecting categories and subcategories
- Modify dashboard to show totals by categories, and when selecting one, show the total by month for that category